### PR TITLE
Support customer rates from database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skypro"
-version = "1.0.0"
+version = "1.1.0"
 description = "Skyprospector by Cepro"
 authors = ["damonrand <damon@cepro.energy>"]
 license = "AGPL-3.0"

--- a/src/skypro/commands/report/main.py
+++ b/src/skypro/commands/report/main.py
@@ -296,11 +296,19 @@ def report(
         time_index=time_index,
         rates_by_category=rates.mkt_fix,
         allow_vol_rates=False,
+        allow_fix_rates=True,
     )
-    customer_fixed_cost_dfs, customer_vol_rates_dfs = get_rates_dfs_by_type(
+    _, customer_vol_rates_dfs = get_rates_dfs_by_type(
         time_index=time_index,
-        rates_by_category=rates.customer,
+        rates_by_category=rates.customer_vol,
         allow_vol_rates=True,
+        allow_fix_rates=False,
+    )
+    customer_fixed_cost_dfs, _ = get_rates_dfs_by_type(
+        time_index=time_index,
+        rates_by_category=rates.customer_fix,
+        allow_vol_rates=False,
+        allow_fix_rates=True
     )
 
     return Report(

--- a/src/skypro/commands/report/microgrid_flow_calcs.py
+++ b/src/skypro/commands/report/microgrid_flow_calcs.py
@@ -156,8 +156,7 @@ def calculate_missing_net_flows_in_junction(
             pct_missing = (nans_df[col_to_predict].sum() / len(nans_df)) * 100
             df.loc[rows_to_predict, col_to_predict] = total * col_to_predict_direction
             notices.append(Notice(
-                detail=f"{pct_missing:.1f}% of '{col_to_predict}' fields are missing, but {pct_to_fill:.1f}% can be calculated"
-                    " using redundant microgrid metering data",
+                detail=f"{pct_missing:.1f}% of '{col_to_predict}' fields are missing, but {pct_to_fill:.1f}% can be calculated using redundant microgrid metering data",
                 level=pct_to_notice_level(pct_missing)
             ))
 

--- a/src/skypro/commands/report/rates.py
+++ b/src/skypro/commands/report/rates.py
@@ -8,7 +8,7 @@ from skypro.common.config.rates_parse_db import get_rates_from_db
 from skypro.common.data.get_timeseries import get_timeseries
 from skypro.common.notice.notice import Notice
 from skypro.common.rate_utils.to_dfs import VolRatesForEnergyFlows
-from skypro.common.rates.rates import FixedRate, Rate, VolRate
+from skypro.common.rates.rates import FixedRate, VolRate
 from skypro.common.timeutils.timeseries import get_steps_per_hh, get_step_size
 
 from skypro.commands.report.config.config import Config

--- a/src/skypro/commands/report/warnings.py
+++ b/src/skypro/commands/report/warnings.py
@@ -15,8 +15,8 @@ def missing_data_warnings(df: pd.DataFrame, data_name: str) -> List[Notice]:
         return [
              Notice(
                 detail=f"{pct:.1f}% of '{data_name}' data is missing ({num_missing} NaN fields)",
-                level=pct_to_notice_level(pct)
-            )
+                level=pct_to_notice_level(pct),
+             )
         ]
 
     return []

--- a/src/skypro/common/config/data_source.py
+++ b/src/skypro/common/config/data_source.py
@@ -89,7 +89,7 @@ class ProfileDataSource:
     constant_profile_data_source: Optional[ConstantProfileDataSource] = field_with_opts(key="constant")
 
     def __post_init__(self):
-        enforce_one_option([self.csv_profile_data_source, self.constant_profile_data_source],"'csvProfile', 'constant'")
+        enforce_one_option([self.csv_profile_data_source, self.constant_profile_data_source], "'csvProfile', 'constant'")
 
 
 @dataclass

--- a/src/skypro/common/config/rates_dataclasses.py
+++ b/src/skypro/common/config/rates_dataclasses.py
@@ -20,6 +20,15 @@ class SiteSpecifier:
 
 
 @dataclass
+class CustomerRatesDB:
+    """
+    Configures rates for customers (i.e. domestic homes) to be pulled from a database
+    """
+    import_bundles: List[str] = field_with_opts(key="importBundles")  # Names of any import rate bundles to use for the customer load
+    export_bundles: List[str] = field_with_opts(key="exportBundles")  # Names of any export rate bundles to use for the customer export
+
+
+@dataclass
 class RatesDB:
     """
     Configures rates to be pulled from a database.
@@ -29,6 +38,7 @@ class RatesDB:
     import_bundles: List[str] = field_with_opts(key="importBundles")  # Names of any import rate bundles to use in addition to the site specific ones (e.g. Supplier arrangements)
     export_bundles: List[str] = field_with_opts(key="exportBundles")  # Names of any export rate bundles to use in addition to the site specific ones (e.g. Supplier arrangements).
     future_offset_str: Optional[str] = field_with_opts(key="futureOffset")  # For simulations, it can be useful to bring the rates forwards in time, for example we might want to use the 2025 rates for a simulation run over 2024
+    customer: Optional[CustomerRatesDB]  # Optionally define rates for customers - these are only really used for reporting purposes as this doesn't affect control algorithms
 
 
 @dataclass

--- a/src/skypro/common/config/rates_parse_db.py
+++ b/src/skypro/common/config/rates_parse_db.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from skypro.common.rate_utils.to_dfs import VolRatesForEnergyFlows
-from skypro.common.rates.rates import RegularFixedRate, MultiplierVolRate, ShapedVolRate, FlatVolRate, OSAMFlatVolRate, PeriodicFlatVolRate, FixedRate, VolRate, Rate
+from skypro.common.rates.rates import RegularFixedRate, MultiplierVolRate, ShapedVolRate, FlatVolRate, OSAMFlatVolRate, PeriodicFlatVolRate, FixedRate, VolRate
 from skypro.common.rates.supply_point import SupplyPoint
 from skypro.common.rates.time_varying_value import PeriodicValue
 from skypro.common.timeutils import ClockTimePeriod

--- a/src/skypro/common/data/get_plot_meter_readings.py
+++ b/src/skypro/common/data/get_plot_meter_readings.py
@@ -115,7 +115,7 @@ def _get_csv_plot_meter_readings(
         "energyImportedActiveDelta": "kwh",
     })
 
-    df = df[df["feeder_id"].isin([str(id) for id in source.feeder_ids])]
+    df = df[df["feeder_id"].isin([str(feeder_id) for feeder_id in source.feeder_ids])]
 
     # Remove any data that is outside the time range of interest
     # TODO: only read in CSVs for the months that are required in the first place

--- a/src/skypro/common/rate_utils/to_dfs.py
+++ b/src/skypro/common/rate_utils/to_dfs.py
@@ -105,7 +105,8 @@ def get_vol_rates_dfs(time_index: pd.DatetimeIndex, all_rates: VolRatesForEnergy
 def get_rates_dfs_by_type(
         time_index: pd.DatetimeIndex,
         rates_by_category: Dict[str, List[Rate]],
-        allow_vol_rates: bool
+        allow_vol_rates: bool,
+        allow_fix_rates: bool,
 ) -> (Dict[str, pd.DataFrame], Dict[str, pd.DataFrame]):
     """Returns two dictionaries of dataframes:
        - The first has dataframes containing any fixed costs in pence, keyed by category
@@ -122,6 +123,8 @@ def get_rates_dfs_by_type(
         for rate in rates:
             # Fixed costs and volume-based rates go into different columns
             if isinstance(rate, FixedRate):
+                if not allow_fix_rates:
+                    raise ValueError("Fixed rate found but not allowed")
                 fixed_costs_dfs[category][rate.name] = rate.get_cost_series(time_index)
             elif isinstance(rate, VolRate):
                 if not allow_vol_rates:


### PR DESCRIPTION
This allows the 'customer rates' to be specified when using a rates database- previously this was only supported using rates YAML files.